### PR TITLE
Fix warning from unsafe yaml loader

### DIFF
--- a/dotrunner/dotrunner.py
+++ b/dotrunner/dotrunner.py
@@ -17,7 +17,7 @@ class FileSystemIO(object):
     def yaml(self, f):
         try:
             with open(f) as fp:
-                return yaml.load(fp)
+                return yaml.safe_load(fp)
         except:  # noqa
             return None
 


### PR DESCRIPTION
Solving `dot/lib/python3.7/site-packages/dotrunner/dotrunner.py:20: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.`